### PR TITLE
Replace Spotify API with local mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@
 
 🎵 React Redux: For global state management and smooth data flow across the app.
 
-🎵 <a href="https://developer.spotify.com/documentation/web-api/">Spotify Web API</a>: To fetch data like playlists, albums, and user information.
-
 🎵 <a href="https://developer.spotify.com/documentation/web-playback-sdk/">Spotify Playback SDK</a>: For real-time music playback control within the web client.
+
+ℹ️ **Mock API**: The original Spotify Web API integration has been removed. Mock responses are used for local testing.
 
 ## 📸 Screenshots
 
@@ -95,20 +95,25 @@ To run this project locally, follow these steps:
    yarn install
    ```
 
-4. Set up your Spotify Developer account and create a [new app](https://developer.spotify.com/dashboard/applications) to obtain your **Client ID** and **Redirect URI**. Add these to an `.env` file in the root of your project:
-
-   ```
-   REACT_APP_SPOTIFY_CLIENT_ID=<your id>
-   REACT_APP_SPOTIFY_REDIRECT_URL=<your redirect uri>
-   ```
-
-5. Start the development server:
+4. Start the development server:
 
    ```bash
-   yarn start
-   ```
+ yarn start
+  ```
 
-6. Open your browser and navigate to `http://localhost:3000`.
+5. Open your browser and navigate to `http://localhost:3000`.
+
+### Mock login
+
+When prompted, use the following credentials:
+
+```
+username: demo
+password: password
+```
+
+You can modify these default credentials by editing
+`src/utils/spotify/login.ts`.
 
 ## 🌐 2018 Version
 

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,38 +1,38 @@
-import Axios from 'axios';
-import { getRefreshToken } from './utils/spotify/login';
-import { getFromLocalStorageWithExpiry } from './utils/localstorage';
-
-const path = 'https://api.spotify.com/v1' as const;
-
-const access_token = getFromLocalStorageWithExpiry('access_token') as string;
-
-const axios = Axios.create({
-  baseURL: path,
-  headers: {},
-});
-
-if (access_token) {
-  axios.defaults.headers.common['Authorization'] = 'Bearer ' + access_token;
+export interface AxiosResponse<T> {
+  data: T;
 }
 
-axios.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response.status === 401) {
-      return getRefreshToken()
-        .then((token) => {
-          if (!token) return Promise.reject(error);
-          axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
-          error.config.headers['Authorization'] = 'Bearer ' + token;
-          return axios(error.config);
-        })
-        .catch(() => {
-          localStorage.removeItem('refresh_token');
-          localStorage.removeItem('access_token');
-        });
-    }
-    return Promise.reject(error);
-  }
-);
+// Simple mock axios that returns predefined responses for testing
+import { data as mockData } from './mock/mockData';
+
+const responses: Record<string, any> = { ...mockData };
+
+export const registerResponse = (url: string, data: any) => {
+  responses[url] = data;
+};
+
+interface RequestConfig {
+  params?: Record<string, any>;
+  data?: any;
+  headers?: Record<string, any>;
+}
+
+const get = async <T = any>(url: string, _config?: RequestConfig): Promise<AxiosResponse<T>> => {
+  return { data: responses[url] as T };
+};
+
+const post = async <T = any>(url: string, _data?: any, _config?: RequestConfig): Promise<AxiosResponse<T>> => {
+  return { data: responses[url] as T };
+};
+
+const put = async <T = any>(url: string, _data?: any, _config?: RequestConfig): Promise<AxiosResponse<T>> => {
+  return { data: responses[url] as T };
+};
+
+const del = async <T = any>(url: string, _config?: RequestConfig): Promise<AxiosResponse<T>> => {
+  return { data: responses[url] as T };
+};
+
+const axios = { get, post, put, delete: del, defaults: { headers: { common: {} } } };
 
 export default axios;

--- a/src/mock/mockData.ts
+++ b/src/mock/mockData.ts
@@ -1,0 +1,107 @@
+import { Album } from '../interfaces/albums';
+import { Playlist } from '../interfaces/playlists';
+import { Track } from '../interfaces/track';
+import { Artist } from '../interfaces/artist';
+import { PlayHistoryObject } from '../interfaces/player';
+import { User } from '../interfaces/user';
+
+// Basic mock user for authentication
+export const mockUser: User = {
+  display_name: 'Demo User',
+  external_urls: { spotify: '' },
+  href: '',
+  id: 'demo',
+  images: [],
+  type: 'user',
+  uri: '',
+  followers: { href: null, total: 0 },
+  country: 'US',
+  product: 'premium',
+  explicit_content: { filter_enabled: false, filter_locked: false },
+  email: 'demo@example.com',
+} as any;
+
+export const mockArtist: Artist = {
+  followers: { href: null, total: 0 },
+  genres: [],
+  href: '',
+  id: 'artist1',
+  images: [],
+  name: 'Mock Artist',
+  popularity: 0,
+  type: 'artist',
+  uri: 'artist:1',
+  external_urls: { spotify: '' },
+} as any;
+
+export const mockAlbum: Album = {
+  album_type: 'album',
+  artists: [mockArtist],
+  available_markets: [],
+  external_urls: { spotify: '' },
+  href: '',
+  id: 'album1',
+  images: [],
+  name: 'Mock Album',
+  release_date: '2024-01-01',
+  release_date_precision: 'day',
+  total_tracks: 1,
+  type: 'album',
+  uri: 'album:1',
+} as any;
+
+export const mockTrack: Track = {
+  album: mockAlbum,
+  artists: [mockArtist],
+  available_markets: [],
+  disc_number: 1,
+  duration_ms: 180000,
+  explicit: false,
+  external_ids: { isrc: '' },
+  external_urls: { spotify: '' },
+  href: '',
+  id: 'track1',
+  is_local: false,
+  is_playable: true,
+  name: 'Mock Track',
+  popularity: 0,
+  preview_url: '',
+  track_number: 1,
+  type: 'track',
+  uri: 'track:1',
+} as any;
+
+export const mockPlaylist: Playlist = {
+  collaborative: false,
+  description: 'Mock playlist',
+  external_urls: { spotify: '' },
+  href: '',
+  id: 'playlist1',
+  images: [],
+  followers: { href: '', total: 0 },
+  name: 'Mock Playlist',
+  owner: mockUser,
+  public: true,
+  snapshot_id: '1',
+  tracks: { href: '', total: 1 },
+  type: 'playlist',
+  uri: 'playlist:1',
+} as any;
+
+export const mockPlayHistory: PlayHistoryObject = {
+  track: mockTrack,
+  played_at: new Date().toISOString(),
+  context: { type: 'artist', uri: mockArtist.uri, href: '' },
+} as any;
+
+export const data = {
+  '/me': mockUser,
+  '/me/top/tracks': { items: [mockTrack] },
+  '/browse/new-releases': { albums: { items: [mockAlbum] } },
+  '/browse/featured-playlists': { playlists: { items: [mockPlaylist] } },
+  '/browse/categories/0JQ5DAudkNjCgYMM0TZXDw/playlists': { playlists: { items: [mockPlaylist] } },
+  '/browse/categories/0JQ5DAqbMKFQIL0AXnG5AK/playlists': { playlists: { items: [mockPlaylist] } },
+  '/browse/categories/0JQ5DAt0tbjZptfcdMSKl3/playlists': { playlists: { items: [mockPlaylist] } },
+  '/me/player/recently-played': { items: [mockPlayHistory] },
+  '/me/following': { artists: { items: [mockArtist] } },
+};

--- a/src/utils/spotify/login.ts
+++ b/src/utils/spotify/login.ts
@@ -1,177 +1,27 @@
-import Axios from 'axios';
-import { getFromLocalStorageWithExpiry, setLocalStorageWithExpiry } from '../localstorage';
-import axios from 'axios';
+import { setLocalStorageWithExpiry, getFromLocalStorageWithExpiry } from '../localstorage';
 
-/* eslint-disable import/no-anonymous-default-export */
-const client_id = process.env.REACT_APP_SPOTIFY_CLIENT_ID as string;
-const redirect_uri = process.env.REACT_APP_SPOTIFY_REDIRECT_URL as string;
+const USERNAME = 'demo';
+const PASSWORD = 'password';
+const TOKEN = 'mock-token';
 
-const authUrl = new URL('https://accounts.spotify.com/authorize');
-
-const SCOPES = [
-  'ugc-image-upload',
-  'streaming',
-
-  'user-read-playback-state',
-  'user-modify-playback-state',
-  'user-read-currently-playing',
-
-  'playlist-read-private',
-  'playlist-modify-public',
-  'playlist-modify-private',
-  'playlist-read-collaborative',
-
-  'user-follow-modify',
-  'user-follow-read',
-
-  'user-read-playback-position',
-  'user-top-read',
-  'user-read-recently-played',
-
-  'user-library-read',
-  'user-library-modify',
-] as const;
-
-const sha256 = async (plain: string) => {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(plain);
-  return window.crypto.subtle.digest('SHA-256', data);
-};
-
-const base64encode = (input: ArrayBuffer) => {
-  // @ts-ignore
-  return btoa(String.fromCharCode(...new Uint8Array(input)))
-    .replace(/=/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_');
-};
-
-const generateRandomString = (length: number) => {
-  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const values = crypto.getRandomValues(new Uint8Array(length));
-  return values.reduce((acc, x) => acc + possible[x % possible.length], '');
-};
-
-const logInWithSpotify = async (anonymous?: boolean) => {
-  let codeVerifier = localStorage.getItem('code_verifier');
-
-  if (!codeVerifier) {
-    codeVerifier = generateRandomString(64);
-    localStorage.setItem('code_verifier', codeVerifier);
-  }
-
-  const hashed = await sha256(codeVerifier);
-  const codeChallenge = base64encode(hashed);
-
-  if (anonymous) {
-    authUrl.search = new URLSearchParams({
-      client_id,
-      scope: '',
-      redirect_uri,
-      response_type: 'token',
-    }).toString();
+const logInWithSpotify = async () => {
+  const user = window.prompt('Username');
+  const pass = window.prompt('Password');
+  if (user === USERNAME && pass === PASSWORD) {
+    setLocalStorageWithExpiry('access_token', TOKEN, 3600 * 24);
   } else {
-    authUrl.search = new URLSearchParams({
-      client_id,
-      redirect_uri,
-      response_type: 'code',
-      scope: SCOPES.join(' '),
-      code_challenge_method: 'S256',
-      code_challenge: codeChallenge,
-    }).toString();
+    alert('Invalid credentials');
   }
-  window.location.href = authUrl.toString();
 };
 
-const requestToken = async (code: string) => {
-  const code_verifier = localStorage.getItem('code_verifier') as string;
-
-  const body = {
-    code,
-    client_id,
-    redirect_uri,
-    code_verifier,
-    grant_type: 'authorization_code',
-  };
-
-  const { data: response } = await Axios.post<{
-    access_token: string;
-    token_type: string;
-    expires_in: number;
-    refresh_token: string;
-  }>('https://accounts.spotify.com/api/token', body, {
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  });
-
-  if (response.access_token) {
-    setLocalStorageWithExpiry('access_token', response.access_token, response.expires_in * 60 * 60);
-    axios.defaults.headers.common['Authorization'] = 'Bearer ' + response.access_token;
-    localStorage.setItem('refresh_token', response.refresh_token);
-  }
-
-  return response.access_token;
-};
-
-const getToken = async () => {
+const getToken = async (): Promise<[string | null, boolean]> => {
   const token = getFromLocalStorageWithExpiry('access_token');
-  if (token) return [token, true];
-
-  const urlParams = new URLSearchParams(window.location.search);
-
-  let code = urlParams.get('code') as string;
-  if (code) return [await requestToken(code), true];
-
-  const publicToken = getFromLocalStorageWithExpiry('public_access_token');
-  if (publicToken) return [publicToken, false];
-
-  const access_token = window.location.hash.split('&')[0].split('=')[1];
-  if (access_token) {
-    setLocalStorageWithExpiry('public_access_token', access_token, 3600);
-    window.location.hash = '';
-    return [access_token, false];
-  }
-
-  return [null, false];
+  return [token || null, !!token];
 };
 
-export const getRefreshToken = async () => {
-  // refresh token that has been previously stored
-  const refreshToken = localStorage.getItem('refresh_token') as string;
-
-  if (!refreshToken) {
-    logInWithSpotify(true);
-    return null;
-  }
-
-  const url = 'https://accounts.spotify.com/api/token';
-
-  const payload = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      client_id,
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-    }),
-  };
-  const body = await fetch(url, payload);
-  const response = await body.json();
-
-  if (!response.access_token) {
-    logInWithSpotify(true);
-    return null;
-  }
-
-  setLocalStorageWithExpiry('access_token', response.access_token, response.expires_in * 60 * 60);
-  axios.defaults.headers.common['Authorization'] = 'Bearer ' + response.access_token;
-  if (response.refreshToken) {
-    localStorage.setItem('refresh_token', response.refreshToken);
-  }
-  return response.access_token;
+const getRefreshToken = async () => {
+  const token = getFromLocalStorageWithExpiry('access_token');
+  return token || null;
 };
 
 export default { logInWithSpotify, getToken, getRefreshToken };


### PR DESCRIPTION
## Summary
- strip axios setup and use local mock responses
- add mock data for albums, artists, tracks and user info
- simplify login to use static credentials
- document mock API usage and credentials in the README
- clarify that login credentials can be edited in the source

## Testing
- `yarn test --watchAll=false --passWithNoTests` *(fails: This package doesn't seem to be present in your lockfile without running `yarn install`)*
- `yarn install`
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6844cf02187483279b2711c9dca38156